### PR TITLE
refactor: console warning 제거 (ESM import, Image fill)

### DIFF
--- a/src/app/career/_components/main-content.tsx
+++ b/src/app/career/_components/main-content.tsx
@@ -39,6 +39,7 @@ const MainContent = () => {
                     src={company.logoUrl}
                     alt={company.name}
                     fill
+                    sizes='100px'
                     priority
                     className={cn('object-contain p-[25%]', company.imageClassName)}
                   />

--- a/src/constants/career.ts
+++ b/src/constants/career.ts
@@ -1,11 +1,11 @@
-import { ko, en } from '@/lib/i18n/career.json';
+import careerI18n from '@/lib/i18n/career.json';
 import type { CareerFilterItem } from '@/types/career';
 
 export const CareerFilterList: CareerFilterItem[] = ['supertree', 'd.dive', 'ellen'];
 
 export const careerMockData = {
-  ko,
-  en,
+  ko: careerI18n.ko,
+  en: careerI18n.en,
 };
 
 export const careerKoMap: Record<CareerFilterItem, string> = {


### PR DESCRIPTION
## 작업 종류

- [ ] Bugfix
- [ ] Feature
- [ ] Release
- [x] Refactor
- [ ] Style
- [ ] Environment
- [ ] Other, please describe:

## 작업 요약

- console warning 제거

## 작업 내용 (생략x, 어떤 작업인지 가급적이면 설명, 관련 스크린샷 포함)
- src/constants/career.ts에서 career.json을 default import 방식으로 불러오도록 변경함
→ named import 사용 시 ESM 경고(Should not import the named export) 발생하여 수정

- next/image 컴포넌트에서 `fill, sizes` 관련 경고 제거
→ fill 사용 시 `sizes`를 지정해줘야 성능 향상에 도움이 된다고 함.

![image](https://github.com/user-attachments/assets/f09ac980-6a41-4a8f-be3a-5f701b014358)

## 테스팅 요구사항
- `/career` 에서 console warning 문구가 안뜨는지 확인 필요합니다.