### PR TITLE
fix: getMappedKey 적용하여 한글 필터 탭 버그 수정

### DIFF
--- a/src/app/career/page.tsx
+++ b/src/app/career/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import Divider from '@/components/shared/divider';
@@ -7,6 +8,7 @@ import SectionTitle from '@/components/shared/section-title';
 import SideContent from '@/components/shared/side-content';
 import Sidebar from '@/components/sidebar';
 import { careerKoMap } from '@/constants/career';
+import { getMappedKey } from '@/lib/utils';
 import { useCareerPageStore } from '@/store/use-career-page-store';
 import type { CareerFilterItem } from '@/types/career';
 
@@ -23,10 +25,20 @@ const CareerPage = () => {
     i18n: { language },
   } = useTranslation();
 
-  const handleClick = (text?: string) => {
-    if (!text) return;
-    toggleFilter(text as CareerFilterItem);
-  };
+  const handleClick = useCallback(
+    (text?: string) => {
+      if (!text) return;
+
+      const key =
+        language === 'ko'
+          ? getMappedKey<CareerFilterItem>(careerKoMap, text)
+          : (text as CareerFilterItem);
+      if (!key) return;
+
+      toggleFilter(key);
+    },
+    [language, toggleFilter]
+  );
 
   return (
     <div className='flex flex-col lg:h-full lg:flex-row'>

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,10 +1,12 @@
 'use client';
 
+import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import SectionTitle from '@/components/shared/section-title';
 import Sidebar from '@/components/sidebar';
 import { techKoMap } from '@/constants/projects';
+import { getMappedKey } from '@/lib/utils';
 import { useProjectsPageStore } from '@/store/use-projects-page-store';
 import type { Tech } from '@/types/projects';
 
@@ -21,15 +23,22 @@ const ProjectPage = () => {
     i18n: { language },
   } = useTranslation();
 
-  const handleClick = (text?: string) => {
-    if (!text) return;
-    toggleTech(text as Tech);
-  };
+  const handleClick = useCallback(
+    (text?: string) => {
+      if (!text) return;
+
+      const key = language === 'ko' ? getMappedKey<Tech>(techKoMap, text) : (text as Tech);
+      if (!key) return;
+
+      toggleTech(key);
+    },
+    [language, toggleTech]
+  );
 
   return (
     <div className='flex flex-col lg:h-full lg:flex-row'>
       <Sidebar size='md'>
-        <Sidebar.Container desktopTitle={language === 'ko' ? '경력' : 'career'}>
+        <Sidebar.Container desktopTitle={language === 'ko' ? '프로젝트' : 'project'}>
           <SidebarContent />
         </Sidebar.Container>
       </Sidebar>

--- a/src/components/shared/section-title/section-title-item.tsx
+++ b/src/components/shared/section-title/section-title-item.tsx
@@ -19,9 +19,11 @@ const SectionTitle = ({ onClose, children }: PropsWithChildren<Props>) => {
   return (
     <div className='flex w-60 items-center justify-between border-r border-slate-400 pr-2 pl-6 dark:border-slate-700'>
       <span className='text-body-md text-slate-700 dark:text-slate-500'>{children}</span>
-      <Button size='icon' variant='ghost' onClick={handleClose}>
-        <RxCross2 className='h-4 w-4 text-slate-500' />
-      </Button>
+      {onClose && (
+        <Button size='icon' variant='ghost' onClick={handleClose}>
+          <RxCross2 className='h-4 w-4 text-slate-500' />
+        </Button>
+      )}
     </div>
   );
 };

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -1,4 +1,12 @@
-import { cn } from '../utils';
+import { cn, getMappedKey } from '../utils';
+
+const mockMap = {
+  supertree: '수퍼트리',
+  'd.dive': '디다이브',
+  ellen: '엘렌',
+} as const;
+
+type MockKey = keyof typeof mockMap;
 
 describe('cn 함수 (className 유틸리티)', () => {
   it('문자열 클래스들을 공백으로 잘 병합한다', () => {
@@ -19,5 +27,21 @@ describe('cn 함수 (className 유틸리티)', () => {
 
   it('tailwind-merge에 의해 충돌 클래스는 병합된다 (예: px-2 + px-4 → px-4)', () => {
     expect(cn('px-2', 'px-4')).toBe('px-4');
+  });
+});
+
+describe('getMappedKey 함수', () => {
+  it('value에 해당하는 key를 정확히 반환한다', () => {
+    expect(getMappedKey<MockKey>(mockMap, '디다이브')).toBe('d.dive');
+    expect(getMappedKey<MockKey>(mockMap, '수퍼트리')).toBe('supertree');
+    expect(getMappedKey<MockKey>(mockMap, '엘렌')).toBe('ellen');
+  });
+
+  it('일치하는 value가 없으면 undefined를 반환한다', () => {
+    expect(getMappedKey<MockKey>(mockMap, '없는 값')).toBeUndefined();
+  });
+
+  it('빈 문자열 입력 시 undefined를 반환한다', () => {
+    expect(getMappedKey<MockKey>(mockMap, '')).toBeUndefined();
   });
 });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -2,3 +2,8 @@ import { clsx, type ClassValue } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 
 export const cn = (...inputs: ClassValue[]): string => twMerge(clsx(inputs));
+
+export const getMappedKey = <T extends string>(
+  map: Record<T, string>,
+  text: string
+): T | undefined => Object.entries(map).find(([, value]) => value === text)?.[0] as T;


### PR DESCRIPTION
## 작업 종류

- [x] Bugfix
- [ ] Feature
- [ ] Release
- [ ] Refactor
- [ ] Style
- [ ] Environment
- [ ] Other, please describe:

## 작업 요약

- getMappedKey 적용하여 한글 필터 탭 버그 수정

## 작업 내용 (생략x, 어떤 작업인지 가급적이면 설명, 관련 스크린샷 포함)

- closed #12
- 사이트에서 선택한 언어가 `한국어(ko)` 일 경우에, Filter 기능이 제대로 작동 안하던 버그 수정
- value(한국어)를 가지고 key(영어)를 return 해주는 공통 함수 `getMappedKey` 추가 및 테스트 코드 작성
- `career, projects` 페이지에 적용 완료

- 버그 수정 전 (Tab을 닫아도 빈 탭이 생김)
![image](https://github.com/user-attachments/assets/9f3cb2f7-9390-48a3-a41c-86b5070d8714)

- 버그 수정 후 (Tab이 정상적으로 닫힘)
![image](https://github.com/user-attachments/assets/59d56a9b-0ffd-4c59-86a7-d2c2a97557d9)

## 테스팅 요구사항
- 사이트 언어를 한국어(ko)로 설정 후
- `/career, /projects` 페이지에서 Filter 기능이 정상 작동하는지 확인 필요
- 좌측 Filter 혹은 상단 Tab에서 X 버튼 클릭시 정상적으로 Filter 기능이 작동해야 함.
