### PR TITLE
feat: 선택된 필터/기술 항목 정렬 기능 추가

### DIFF
--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -1,4 +1,4 @@
-import { cn, getMappedKey } from '../utils';
+import { cn, getMappedKey, sortByReference } from '../utils';
 
 const mockMap = {
   supertree: '수퍼트리',
@@ -43,5 +43,30 @@ describe('getMappedKey 함수', () => {
 
   it('빈 문자열 입력 시 undefined를 반환한다', () => {
     expect(getMappedKey<MockKey>(mockMap, '')).toBeUndefined();
+  });
+});
+
+describe('sortByReference 함수', () => {
+  const reference = ['supertree', 'd.dive', 'ellen'] as const;
+  type Ref = (typeof reference)[number];
+
+  const isInReference = (value: string): value is Ref => reference.includes(value as Ref);
+
+  it('target 배열을 reference 순서대로 정렬한다', () => {
+    const target = ['ellen', 'supertree'] as const;
+    const result = sortByReference([...target], [...reference]);
+    expect(result).toEqual(['supertree', 'ellen']);
+  });
+
+  it('target 배열이 빈 배열이면 빈 배열을 반환한다', () => {
+    const result = sortByReference([], [...reference]);
+    expect(result).toEqual([]);
+  });
+
+  it('target이 reference에 없는 값을 포함해도 무시된다', () => {
+    const target = ['unknown', 'supertree'];
+    const filtered = target.filter(isInReference);
+    const result = sortByReference(filtered, [...reference]);
+    expect(result).toEqual(['supertree']);
   });
 });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -7,3 +7,6 @@ export const getMappedKey = <T extends string>(
   map: Record<T, string>,
   text: string
 ): T | undefined => Object.entries(map).find(([, value]) => value === text)?.[0] as T;
+
+export const sortByReference = <T>(target: T[], reference: T[]): T[] =>
+  reference.filter(item => target.includes(item));

--- a/src/store/use-career-page-store.ts
+++ b/src/store/use-career-page-store.ts
@@ -1,6 +1,7 @@
 import { useShallow } from 'zustand/react/shallow';
 
 import { careerFilterList } from '@/constants/career';
+import { sortByReference } from '@/lib/utils';
 import type { CareerFilterItem } from '@/types/career';
 
 import { createStore } from '.';
@@ -20,10 +21,12 @@ export const careerPageStore = createStore<CareerPageStore>(
     toggleFilter: filter => {
       set(state => {
         const exists = state.selectedFilter.includes(filter);
+        const next = exists
+          ? state.selectedFilter.filter(item => item !== filter)
+          : [...state.selectedFilter, filter];
+
         return {
-          selectedFilter: exists
-            ? state.selectedFilter.filter(item => item !== filter)
-            : [...state.selectedFilter, filter],
+          selectedFilter: sortByReference(next, careerFilterList),
         };
       });
     },

--- a/src/store/use-projects-page-store.ts
+++ b/src/store/use-projects-page-store.ts
@@ -1,6 +1,7 @@
 import { useShallow } from 'zustand/react/shallow';
 
 import { techList } from '@/constants/projects';
+import { sortByReference } from '@/lib/utils';
 import type { Tech } from '@/types/projects';
 
 import { createStore } from '.';
@@ -20,10 +21,12 @@ export const projectsPageStore = createStore<ProjectsPageStore>(
     toggleTech: tech => {
       set(state => {
         const exists = state.selectedTechs.includes(tech);
+        const next = exists
+          ? state.selectedTechs.filter(item => item !== tech)
+          : [...state.selectedTechs, tech];
+
         return {
-          selectedTechs: exists
-            ? state.selectedTechs.filter(item => item !== tech)
-            : [...state.selectedTechs, tech],
+          selectedTechs: sortByReference(next, techList),
         };
       });
     },


### PR DESCRIPTION
## 작업 종류

- [ ] Bugfix
- [x] Feature
- [ ] Release
- [ ] Refactor
- [ ] Style
- [ ] Environment
- [ ] Other, please describe:

## 작업 요약

- 선택된 필터/기술 항목 정렬 기능 추가

## 작업 내용 (생략x, 어떤 작업인지 가급적이면 설명, 관련 스크린샷 포함)

- closed #13
- `career, projects` 페이지에서 Filter 기능을 사용시, 표시되는 컨텐츠의 정렬이 일정하게 유지되는 기능 추가
- 관련하여 공통으로 사용 할 `sortByReference` 함수 추가 및 테스트 코드 작성

- AS-IS (수퍼트리가 디다이브보다 아래에 있음)
![image](https://github.com/user-attachments/assets/71c2a074-6daf-49bc-887f-6e2df3fe32fa)

- TO-BE (수퍼트리 > 디다이브 > 엘렌 순으로 고정)
![image](https://github.com/user-attachments/assets/10477886-f96c-42a8-8810-f60e1eebdea9)

## 테스팅 요구사항

- `/career`에서 Filter 기능 사용시 우측의 Contents, Tab의 순서가 일정한지 확인
- 순서는 수퍼트리 > 디다이브 > 엘렌 고정. (`careerFilterList` 기준)
